### PR TITLE
fix(projects): 修复git路径

### DIFF
--- a/src/command/git-verify.ts
+++ b/src/command/git-verify.ts
@@ -1,8 +1,10 @@
 import { readFileSync } from 'fs';
 import { bgRed, red, green } from 'kolorist';
 
-export function gitCommitVerify(cwd = process.cwd()) {
-  const gitMsgPath = `${cwd}/.git/COMMIT_EDITMSG`;
+export async function gitCommitVerify() {
+  const { execa } = await import('execa');
+  const { stdout: gitPath } = await execa('git', ['rev-parse', '--show-toplevel']);
+  const gitMsgPath = `${gitPath}/.git/COMMIT_EDITMSG`;
 
   const commitMsg = readFileSync(gitMsgPath, 'utf-8').trim();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ async function setupCli() {
     'git-commit-verify': {
       desc: '校验 git 的 commit 是否符合 Angular 规范',
       action: () => {
-        gitCommitVerify(cliOptions.cwd);
+        gitCommitVerify();
       }
     },
     cleanup: {


### PR DESCRIPTION
当git路径与cwd不一致时，gitCommitVerify无法正确执行。
这里利用git指令来获取git的路径，能够避免这个问题。